### PR TITLE
fix: launch bundled plugin when opentofu plugin is not declared

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ A Docker-based installation will be available in a future release.
 TofuLint comes bundled with a [Terraform language ruleset](https://github.com/SoeldnerConsult/tofulint-ruleset-opentofu), enabling recommended rules by default.
 
 ### Enabling the Opentofu Plugin
-Declare the plugin block in your `.tflint.hcl` or `.tofulint.hcl`:
+The bundled `opentofu` ruleset is enabled automatically — no configuration is required to get started.
+
+If you want to pin a specific release of the ruleset instead of using the bundled one, declare the plugin block in your `.tflint.hcl` or `.tofulint.hcl` and run `tofulint --init`:
 
 ```hcl
 plugin "opentofu" {
@@ -63,48 +65,8 @@ plugin "opentofu" {
   source = "github.com/SoeldnerConsult/tofulint-ruleset-opentofu"
 }
 ```
-> Even though tofulint currently comes with the opentofu plugin pre-packaged, it is still necessary to enable th plugin manually with the given plugin source. This is due to a bug in tofulint source code.
 
 More details: [TFLint Terraform Ruleset Configuration](https://github.com/SoeldnerConsult/tofulint-ruleset-opentofu/blob/main/docs/configuration.md)
-
-
-## Known Issues
-
-### Broken Pre-bundled Installation
-
-**Status:** Investigation Ongoing
-
-**Description**  
-Currently, the automatic installation of the `tofulint-ruleset-opentofu` plugin fails during the standard `tofulint` setup. While this ruleset is intended to be pre-bundled, the application currently fails to initialize it upon startup.
-
-**Symptoms**  
-When running `tofulint` immediately after installation, the application fails to initialize the plugin and suggests running the initialization command manually:
-
-```bash
-$ tofulint
-'Failed to initialize plugins; Plugin "opentofu" not found. Did you run "tofulint --init"?'
-```
-
-**Technical Details**  
-Attempting to resolve the issue by running `tofulint --init` reveals a malformed URL error during the fetch process. The installer appears to be constructing a GitHub API request without the necessary repository or host information:
-
-```bash
-$ tofulint --init
-Installing "opentofu" plugin...
-Failed to install a plugin; Failed to fetch GitHub releases: Get "https:///api/v3/repos///releases/tags/v0.0.7": http: no Host in request URL
-```
-
-> **Note:** The specific code responsible for generating the malformed URL (`http: no Host in request URL`) has not yet been identified.
-
-**Fix**  
-Right now the only available fix is to manually install the opentofu plugin. Therefore define an `.tflint.hcl` or `.tofulint.hcl` file and manually define the necessary opentofu plugin:
-``` hcl
-plugin "opentofu" {
-  enabled = true
-  version = "0.0.9"
-  source = "github.com/SoeldnerConsult/tofulint-ruleset-opentofu"
-}
-```
 
 
 ### Cloud Provider Plugins

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -416,11 +416,12 @@ func (c *Config) enableBundledPlugin() *Config {
 	if _, exists := c.Plugins["opentofu"]; !exists {
 		log.Print(`[INFO] The "opentofu" plugin block is not found. Enable the plugin "opentofu" automatically`)
 
+		// Version and Source are intentionally left empty: ManuallyInstalled()
+		// must return true so that discovery falls back to the bundled plugin
+		// and "tofulint --init" does not try to download it from GitHub.
 		c.Plugins["opentofu"] = &PluginConfig{
 			Name:    "opentofu",
 			Enabled: true,
-			Version: "0.0.7",
-			Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 			Body:    f.Body,
 		}
 

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -120,8 +120,6 @@ plugin "baz" {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},
@@ -161,8 +159,6 @@ config {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},
@@ -192,8 +188,6 @@ config {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},
@@ -376,8 +370,6 @@ plugin "foo" {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},
@@ -415,8 +407,6 @@ config {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},
@@ -445,8 +435,6 @@ config {
 					"opentofu": {
 						Name:    "opentofu",
 						Enabled: true,
-						Version: "0.0.7",
-						Source:  "github.com/SoeldnerConsult/tofulint-ruleset-opentofu",
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #50.

## What

Removes `Version` and `Source` from the plugin config injected by `enableBundledPlugin()` in `tflint/config.go`, matching how upstream TFLint injects its bundled `terraform` plugin.

## Why

As detailed in #50, setting those two fields on the injected config caused both symptoms of the "Broken Pre-bundled Installation" known issue:

1. `Discovery()` only falls back to the bundled plugin when `ManuallyInstalled()` is true (i.e. `Version`/`Source` empty), so a fresh install failed with `Plugin "opentofu" not found. Did you run "tofulint --init"?` instead of launching the bundled ruleset.
2. `tofulint --init` then tried to download the plugin, but since the injected config never goes through `PluginConfig.validate()`, the parsed source fields were empty and `newGitHubClient()` built the malformed Enterprise URL `https:///api/v3/repos///releases/tags/v0.0.7` (`http: no Host in request URL`).

With this change:

- a fresh install lints out of the box using the bundled ruleset
- `tofulint --init` no longer attempts the broken download
- pinning a release via an explicit `plugin "opentofu"` block in `.tflint.hcl` still works (those blocks go through `validate()`)

## Changes

- `tflint/config.go`: drop `Version`/`Source` from the injected bundled plugin config (with a comment explaining why they must stay empty)
- `tflint/config_test.go`: update expectations accordingly
- `README.md`: remove the now-fixed Known Issue section and update the "Enabling the Opentofu Plugin" section (the manual plugin block is now optional)

## Verification

- Built the binary and ran `tofulint` in a clean directory with no config and an empty plugin dir: it lints using the bundled ruleset (previously failed with the "Did you run --init?" error).
- Ran `tofulint --init` in the same setup: exits 0 without attempting a download (previously failed with the malformed URL error).
- `go test` passes for the `tflint` and `cmd` packages. The `plugin` package has pre-existing fixture-dependent failures on `master` (missing pre-built stub plugin binaries) that are unrelated to this change.
